### PR TITLE
Altera PATH do interpretador Python

### DIFF
--- a/kill-router.py
+++ b/kill-router.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import requests


### PR DESCRIPTION
Altera PATH do interpretador Python, desde modo é possível utilizar virtualenv, por exemplo.